### PR TITLE
Support for Batty tests

### DIFF
--- a/examples/batty.py
+++ b/examples/batty.py
@@ -26,13 +26,9 @@ def hello(target):
 def hello_event():
     return "hello"
 
-robot.commands += ['hello']
-robot.hello = hello
+robot.register_command("hello", hello)
 
-robot.events["hello"] = {
-    "source": hello_event,
-    "interval": 0.1,
-}
+robot.register_event("hello", hello_event)
 
 api = zorg.api("zorg.api.Http", {})
 
@@ -42,8 +38,7 @@ def echo(message=None):
 
     return message
 
-api.commands += ['echo']
-api.echo = echo
+api.register_command("echo", echo)
 
 robot.start()
 api.start()

--- a/examples/batty.py
+++ b/examples/batty.py
@@ -30,7 +30,7 @@ api = zorg.api("zorg.api.Http", {})
 
 def echo(message=None):
     if message is None:
-        return "No value passed to echo"
+        raise Exception("No value passed to echo")
 
     return message
 

--- a/examples/batty.py
+++ b/examples/batty.py
@@ -1,0 +1,20 @@
+import zorg
+
+robot = zorg.robot({
+    "name": "TestBot",
+    "work": None,
+})
+
+api = zorg.api("zorg.api.Http", {})
+
+def echo(message=None):
+    if message is None:
+        return "No value passed to echo"
+
+    return message
+
+api.commands += ['echo']
+api.echo = echo
+
+robot.start()
+api.start()

--- a/examples/batty.py
+++ b/examples/batty.py
@@ -23,8 +23,16 @@ robot = zorg.robot({
 def hello(target):
     return "Hello, %s!" % target
 
+def hello_event():
+    return "hello"
+
 robot.commands += ['hello']
 robot.hello = hello
+
+robot.events["hello"] = {
+    "source": hello_event,
+    "interval": 0.1,
+}
 
 api = zorg.api("zorg.api.Http", {})
 

--- a/examples/batty.py
+++ b/examples/batty.py
@@ -7,6 +7,7 @@ robot = zorg.robot({
         "loopback": {
             "adaptor": "zorg.adaptor.Loopback",
             "port": "/dev/null",
+            "test": "abc",
         }
     },
     "devices": {
@@ -14,6 +15,7 @@ robot = zorg.robot({
             "connection": "loopback",
             "driver": "zorg.driver.Ping",
             "pin": 13,
+            "test": "abc",
         }
     }
 })

--- a/examples/batty.py
+++ b/examples/batty.py
@@ -3,6 +3,19 @@ import zorg
 robot = zorg.robot({
     "name": "TestBot",
     "work": None,
+    "connections": {
+        "loopback": {
+            "adaptor": "zorg.adaptor.Loopback",
+            "port": "/dev/null",
+        }
+    },
+    "devices": {
+        "ping": {
+            "connection": "loopback",
+            "driver": "zorg.driver.Ping",
+            "pin": 13,
+        }
+    }
 })
 
 api = zorg.api("zorg.api.Http", {})

--- a/examples/batty.py
+++ b/examples/batty.py
@@ -18,6 +18,12 @@ robot = zorg.robot({
     }
 })
 
+def hello(target):
+    return "Hello, %s!" % target
+
+robot.commands += ['hello']
+robot.hello = hello
+
 api = zorg.api("zorg.api.Http", {})
 
 def echo(message=None):

--- a/zorg/adaptor.py
+++ b/zorg/adaptor.py
@@ -13,9 +13,13 @@ class Adaptor(object):
         if "name" in details:
             del details["name"]
 
+        adaptor = details.pop("adaptor", "")
+        adaptor = adaptor.split(".")[-1]
+
         return {
             "name": self.name,
-            #"details": self.options,
+            "adaptor": adaptor,
+            "details": details,
         }
 
     def connect(self):

--- a/zorg/adaptor.py
+++ b/zorg/adaptor.py
@@ -5,11 +5,17 @@ class Adaptor(object):
         self.host = options.get("host", None)
         self.port = options.get("port", None)
 
+        self.options = options
+
     def serialize(self):
+        details = self.options.copy()
+
+        if "name" in details:
+            del details["name"]
+
         return {
             "name": self.name,
-            "host": self.host,
-            "port": self.port,
+            #"details": self.options,
         }
 
     def connect(self):

--- a/zorg/adaptor.py
+++ b/zorg/adaptor.py
@@ -17,3 +17,12 @@ class Adaptor(object):
 
     def disconnect(self):
         raise Exception("This method needs to be overidden in child classes")
+
+
+class Loopback(Adaptor):
+
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass

--- a/zorg/api.py
+++ b/zorg/api.py
@@ -180,6 +180,27 @@ class HttpRequestHandler(BaseHTTPRequestHandler):
             "result": result,
         }
 
+    def handle_robots_connections(self, robot_name, connection_name=None):
+        from zorg import main
+
+        robots = main.robots
+        robot = robots[robot_name]
+
+        if connection_name:
+            connection = robot.helper.initialize_connection(connection_name)
+
+            response = {
+                "connection": connection.serialize(),
+            }
+        else:
+            connections = robot.serialize_connections()
+
+            response = {
+                "connections": connections,
+            }
+
+        return response
+
     def handle_robots_devices(self, robot_name, device_name=None):
         from zorg import main
 

--- a/zorg/api.py
+++ b/zorg/api.py
@@ -268,7 +268,7 @@ class HttpRequestHandler(BaseHTTPRequestHandler):
         }
 
     def handle_robots_devices_events(
-        self, robot_name, device_name, event_name
+        self, robot_name, device_name, event_name=None
     ):
         from zorg import main
 

--- a/zorg/api.py
+++ b/zorg/api.py
@@ -149,6 +149,37 @@ class HttpRequestHandler(BaseHTTPRequestHandler):
 
         return response
 
+    def handle_robots_commands(self, robot_name, command_name=None):
+        from zorg import main
+
+        if command_name:
+            return self.handle_robot_command(robot_name, command_name)
+
+        robots = main.robots
+        robot = robots[robot_name]
+
+        response = {
+            "commands": robot.commands,
+        }
+
+        return response
+
+    def handle_robot_command(self, robot_name, command_name):
+        from zorg import main
+
+        robots = main.robots
+        robot = robots[robot_name]
+
+        command = getattr(robot, command_name)
+
+        command_arguments = self.parse_command_body()
+
+        result = command(*command_arguments)
+
+        return {
+            "result": result,
+        }
+
     def handle_robots_devices(self, robot_name, device_name=None):
         from zorg import main
 

--- a/zorg/commands.py
+++ b/zorg/commands.py
@@ -1,0 +1,27 @@
+class CommandsMixin(object):
+
+    def __init__(self, *args, **kwargs):
+        self.commands = {}
+
+        super(CommandsMixin, self).__init__(*args, **kwargs)
+
+    def register_command(self, command_name, command_source):
+        self.commands[command_name] = command_source
+
+    def run_command(self, command_name, command_arguments=None):
+        if not command_arguments:
+            command_arguments = []
+
+        command = self.commands[command_name]
+
+        return command(*command_arguments)
+
+    def serialize(self):
+        serialized = super(CommandsMixin, self).serialize()
+
+        serialized["commands"] = self.serialize_commands()
+
+        return serialized
+
+    def serialize_commands(self):
+        return self.commands.keys()

--- a/zorg/driver.py
+++ b/zorg/driver.py
@@ -6,6 +6,8 @@ class Driver(object):
         self.pin = options.get("pin", None)
         self.interval = options.get("interval", 10)
 
+        self.options = options
+
         self.connection = connection
 
         self.commands = []
@@ -18,12 +20,24 @@ class Driver(object):
         raise Exception("This needs to be implemented by the child class")
 
     def serialize(self):
+        details = self.options.copy()
+
+        if "name" in details:
+            del details["name"]
+
+        if "connection" in details:
+            del details["connection"]
+
+        driver = details.pop("driver", "")
+        driver = driver.split(".")[-1]
+
         return {
             "name": self.name,
-            "pin": self.pin,
+            "driver": driver,
             "connection": self.connection_name,
             "commands": self.commands,
             "events": self.events,
+            "details": details,
         }
 
 

--- a/zorg/driver.py
+++ b/zorg/driver.py
@@ -25,3 +25,14 @@ class Driver(object):
             "commands": self.commands,
             "events": self.events,
         }
+
+
+class Ping(Driver):
+
+    def __init__(self, *args, **kwargs):
+        super(Ping, self).__init__(*args, **kwargs)
+
+        self.commands += ['ping']
+
+    def ping(self):
+        return "pong"

--- a/zorg/driver.py
+++ b/zorg/driver.py
@@ -1,7 +1,8 @@
+from .commands import CommandsMixin
 from .events import EventsMixin
 
 
-class Driver(EventsMixin):
+class Driver(CommandsMixin, EventsMixin):
 
     def __init__(self, options, connection):
         super(Driver, self).__init__()
@@ -17,8 +18,6 @@ class Driver(EventsMixin):
         self.options = options
 
         self.connection = connection
-
-        self.commands = []
 
     def start(self):
         raise Exception("This needs to be implemented by the child class")
@@ -44,7 +43,6 @@ class Driver(EventsMixin):
             "name": self.name,
             "driver": driver,
             "connection": self.connection_name,
-            "commands": self.commands,
             "details": details,
         })
 
@@ -56,11 +54,9 @@ class Ping(Driver):
     def __init__(self, *args, **kwargs):
         super(Ping, self).__init__(*args, **kwargs)
 
-        self.commands += ["ping"]
-        self.events["ping"] = {
-            "source": self.ping,
-            "interval": 0.1,
-        }
+        self.register_command("ping", self.ping)
+
+        self.register_event("ping", self.ping)
 
     def start(self):
         pass

--- a/zorg/events.py
+++ b/zorg/events.py
@@ -68,6 +68,12 @@ class EventsMixin(object):
 
         return event_stream
 
+    def register_event(self, name, source, interval=0.1):
+        self.events[name] = {
+            "source": source,
+            "interval": interval,
+        }
+
     def serialize(self):
         return {
             "events": self.serialize_events(),

--- a/zorg/events.py
+++ b/zorg/events.py
@@ -1,0 +1,77 @@
+from multiprocessing import Process, Queue
+import time
+
+
+class EventStream(object):
+
+    def __init__(self, settings):
+        self.source = settings["source"]
+        self.interval = settings["interval"]
+
+        self.queue = Queue()
+
+    def start(self):
+        process = Process(target=self.process, args=(self.queue, ))
+        process.start()
+
+        self.process = process
+
+        return process
+
+    def stop(self):
+        self.process.terminate()
+
+    def process(self, queue):
+        while True:
+            result = self.source()
+
+            if result == Event.STOP:
+                break
+
+            event = Event(
+                data=result,
+            )
+
+            queue.put(event)
+
+            time.sleep(self.interval)
+
+        queue.put(Event.STOP)
+
+
+class Event(object):
+    STOP = 0xFF
+
+    def __init__(self, data):
+        self.data = data
+
+    def serialize(self):
+        return "data: %s\n\n" % self.data
+
+
+class EventsMixin(object):
+
+    def __init__(self, *args, **kwargs):
+        self.events = {}
+        self.event_streams = {}
+
+        super(EventsMixin, self).__init__(*args, **kwargs)
+
+    def get_event_stream(self, event_name):
+        if event_name in self.event_streams:
+            return self.event_stream[event_name]
+
+        settings = self.events[event_name]
+
+        event_stream = EventStream(settings)
+        event_stream.start()
+
+        return event_stream
+
+    def serialize(self):
+        return {
+            "events": self.serialize_events(),
+        }
+
+    def serialize_events(self):
+        return self.events.keys()

--- a/zorg/robot.py
+++ b/zorg/robot.py
@@ -1,6 +1,7 @@
 from multiprocessing import Process
 from .connection import Connection
 from .device import Device
+from .events import EventsMixin
 
 
 class Helper(object):
@@ -22,6 +23,7 @@ class Helper(object):
 
     def initialize_device(self, name):
         device_config = self.devices[name]
+        device_config["name"] = name
 
         connection_name = device_config["connection"]
 
@@ -37,15 +39,18 @@ class Helper(object):
 
     def initialize_connection(self, name):
         connection_config = self.connections[name]
+        connection_config["name"] = name
 
         connection = Connection(connection_config)
 
         return connection
 
 
-class Robot(object):
+class Robot(EventsMixin):
 
     def __init__(self, options):
+        super(Robot, self).__init__()
+
         self.name = options.get("name", "")
         self.connections = options.get("connections", {})
         self.adaptors = options.get("adaptors", {})
@@ -54,7 +59,6 @@ class Robot(object):
         self.drivers = {}
 
         self.commands = []
-        self.events = []
 
         self.running = False
 
@@ -72,13 +76,16 @@ class Robot(object):
         pass
 
     def serialize(self):
-        return {
+        serialized = super(Robot, self).serialize()
+
+        serialized.update({
             "name": self.name,
             "commands": self.commands,
-            "events": self.events,
             "connections": self.serialize_connections(),
             "devices": self.serialize_devices(),
-        }
+        })
+
+        return serialized
 
     def serialize_connections(self):
         connections = []

--- a/zorg/robot.py
+++ b/zorg/robot.py
@@ -1,4 +1,5 @@
 from multiprocessing import Process
+from .commands import CommandsMixin
 from .connection import Connection
 from .device import Device
 from .events import EventsMixin
@@ -46,7 +47,7 @@ class Helper(object):
         return connection
 
 
-class Robot(EventsMixin):
+class Robot(CommandsMixin, EventsMixin):
 
     def __init__(self, options):
         super(Robot, self).__init__()
@@ -57,8 +58,6 @@ class Robot(EventsMixin):
         self.devices = options.get("devices", {})
 
         self.drivers = {}
-
-        self.commands = []
 
         self.running = False
 
@@ -80,7 +79,6 @@ class Robot(EventsMixin):
 
         serialized.update({
             "name": self.name,
-            "commands": self.commands,
             "connections": self.serialize_connections(),
             "devices": self.serialize_devices(),
         })


### PR DESCRIPTION
Right now this adds initial, not-yet-complete support for [Batty](https://github.com/hybridgroup/batty) to the HTTP API provided by Zorg.

API responses
- MCP
  - [x] Add commands
  - [x] Add events
- Robots
  - [x] Add commands
  - [x] Add events
- Connections
  - [x] Add list
  - [x] Add detail
- Devices
  - [x] Add events
- Errors
  - [x] Correctly handle 404/500 status codes
  - [x] Add nicely formatted error messages

Zorg additions
- Adaptor
  - [x] Loopback adaptor
  - [x] Events using generators
- Drivers
  - [x] Ping driver
  - [x] Events using generators
- Events
  - [x] Event streams
  - [x] Polling event sources
  - [ ] Manually triggered events

Side notes
- Events must conform to the [EventSource specification](https://w3c.github.io/eventsource/).
