### PR TITLE
Add generic mock-adaptor

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,54 @@
+# Testing with Zorg
+
+Automated testing is extremely beneficial to ensure that your
+creations function as expected under various conditions. By
+creating a set of tests to accompany your code you can avoid
+a number of common problems.
+
+1. When you are creating new code, your tests will ensure that your code works as expected.
+2. When you, or others are modifying existing code, your tests will help verify that unanticipated changes have not occured.
+
+Because of the complexity of testing robotics and physical computing projects, Zorg aims to include testing utilities that ease and assist with test creation.
+
+The preferred way to write tests for Zorg is with the [unittest](https://docs.python.org/3/library/unittest.html#module-unittest) module built in to the Python standard library.
+
+## Mock objects
+
+Mock objects can simulate hardware responses so that your tests
+can run independent of various hardware constraints.
+
+### `MockAdaptor`
+
+The mock adaptor simulates an `Adaptor` class in the Zorg framework. The constructor for the mock adapter allows you
+to specify the available pins and their returned output value.
+The methods available to call on the adapter can also be set.
+
+**Example usage of the MockAdaptor**
+
+```python
+from unittest import TestCase
+from zorg.test import MockAdaptor
+
+
+class MockAdaptorTestCase(TestCase):
+
+    def setUp(self):
+        super(MockAdaptorTestCase, self).setUp()
+
+        # outputs = {pin: output value}
+        self.adaptor = MockAdaptor({
+            'outputs': {
+                1: 1,
+                3: 1.0,
+                4: 500,
+                9: 0
+            },
+            'methods': ['digital_read', 'digital_write']
+        })
+
+    def test_read_existing_pin(self):
+        value = self.adaptor.digital_read(1)
+        self.assertEqual(value, 1)
+```
+
+

--- a/tests/test_mock_adaptor.py
+++ b/tests/test_mock_adaptor.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+from zorg.test import MockAdaptor
+
+
+class MockAdaptorTestCase(TestCase):
+
+    def setUp(self):
+        super(MockAdaptorTestCase, self).setUp()
+
+        self.adaptor = MockAdaptor({
+            'outputs': {
+                1: 1,
+                3: 1.0,
+                4: 500,
+                9: 0
+            },
+            'methods': ['digital_read', 'digital_write']
+        })
+
+    def test_read_existing_pin(self):
+        value = self.adaptor.digital_read(1)
+        self.assertEqual(value, 1)
+
+    def test_read_non_existing_pin(self):
+        value = self.adaptor.digital_read(2)
+        self.assertEqual(value, 0)
+
+    def test_write_existing_pin(self):
+        value = self.adaptor.digital_write(1, 0)
+        self.assertEqual(value, 0)
+
+    def test_write_non_existing_pin(self):
+        value = self.adaptor.digital_write(2, 1)
+        self.assertEqual(value, 1)

--- a/zorg/test.py
+++ b/zorg/test.py
@@ -1,0 +1,40 @@
+from zorg.adaptor import Adaptor
+from mock import Mock
+
+
+def MockAdaptor(configuration):
+    """
+    :param configuration: A dictionary with keys of pin numbers and values as
+    the return value from the method call.
+    :param methods: A list of method names that can be called on the adapter.
+
+    For example:
+
+    configuration = {
+        'outputs': {
+            1: 500,
+            3: 1.0,
+            4: 150,
+            9: 0
+        },
+        'methods': ['analog_write', 'analog_read', 'digital_write']
+    }
+    """
+    outputs = configuration.get('outputs', {})
+    methods = configuration.get('methods', [])
+
+    def side_effect(*args):
+        pin_number = args[0]
+        if len(args) > 1:
+            return args[1]
+        elif args and pin_number in outputs:
+            return outputs[pin_number]
+        else:
+            return 0
+
+    mock_adaptor = Mock(spec=Adaptor)
+
+    for method in methods:
+        setattr(mock_adaptor, method, Mock(side_effect=side_effect))
+
+    return mock_adaptor


### PR DESCRIPTION
This adds a new `zorg.test` module which can be used to encompass any additional testing additions in the future. The only current occupant of this module is a new `MockAdaptor` class which is designed to make it easier to configure mock adaptors in tests for drivers.
- [x] Unit tests for test module
- [x] Update documentation
